### PR TITLE
Fix the way roles appear on dashboard

### DIFF
--- a/app/models/dashboard_presenter.rb
+++ b/app/models/dashboard_presenter.rb
@@ -1,8 +1,9 @@
 class DashboardPresenter
 
-  attr_reader :events, :hash
+  attr_reader :user_events, :events, :hash
 
   def initialize(user)
+    @user_events = user.user_events
     @events = user.events
     @hash = make_map_hash(user)
   end

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -21,11 +21,9 @@
   <div class="panel panel-default">
   <h4>Here are your current events:</h4>
 
-  <% @presenter.events.each do |event| %>
-    <h5><%= link_to event.name, event_path(event) %></h5>
-    <% event.roles.each do |role| %>
-      </p>Your role is: <%= role.name %></p>
-      <% end %>
+  <% @presenter.user_events.each do |user_event| %>
+    <h5><%= link_to user_event.event.name, event_path(user_event.event) %></h5>
+  </p>Your role is: <%= user_event.role.name %></p>
   <% end %>
 
   <h4>Create a new event <%= link_to "here.", new_event_path %>


### PR DESCRIPTION
@meganft 
Small fix - dashboard was showing all users' roles for each event, I added user_event to the dashboard presenter and called it in the view so that only the current user's role in each event is displayed. Merge when ready! 👍 